### PR TITLE
chore: moves $httpupgrade and upstream servers to common config

### DIFF
--- a/src/modules/mainsail/filesystem/root/etc/nginx/conf.d/common_vars.conf
+++ b/src/modules/mainsail/filesystem/root/etc/nginx/conf.d/common_vars.conf
@@ -1,0 +1,4 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}

--- a/src/modules/mainsail/filesystem/root/etc/nginx/conf.d/upstreams.conf
+++ b/src/modules/mainsail/filesystem/root/etc/nginx/conf.d/upstreams.conf
@@ -1,0 +1,9 @@
+upstream apiserver {
+    ip_hash;
+    server 127.0.0.1:7125;
+}
+
+upstream mjpgstreamer {
+    ip_hash;
+    server 127.0.0.1:8080;
+}

--- a/src/modules/mainsail/filesystem/root/etc/nginx/sites-available/mainsail
+++ b/src/modules/mainsail/filesystem/root/etc/nginx/sites-available/mainsail
@@ -1,19 +1,3 @@
-map $http_upgrade $connection_upgrade {
-    default upgrade;
-    '' close;
-}
-
-upstream apiserver {
-    #edit your api port here
-    ip_hash;
-    server 127.0.0.1:7125;
-}
-
-upstream mjpgstreamer {
-    ip_hash;
-    server 127.0.0.1:8080;
-}
-
 server {
     listen 80 default_server;
 


### PR DESCRIPTION
This is the simplest way I could think of to remove the upstream dependency from each clients server configuration.

This way, if another web client wants to use the same upstream configuration - they can - without conflicts.

I also moved the `$http_upgrade` map to common configuration, altho this isn't strictly necessary.