### PR TITLE
feat: allow the app.fluidd.xyz origin

### DIFF
--- a/src/modules/klipper_moonraker/filesystem/home/pi/klipper_config/moonraker.conf
+++ b/src/modules/klipper_moonraker/filesystem/home/pi/klipper_config/moonraker.conf
@@ -6,6 +6,8 @@ config_path: ~/klipper_config
 
 [authorization]
 enabled: True
+cors_domains:
+  https://app.fluidd.xyz
 trusted_clients:
  10.0.0.0/8
  127.0.0.0/8


### PR DESCRIPTION
This will allow users of mainsailos moving forward to effectively use fluidd in a remote hosted environment, in a secure way.