### PR TITLE
macro: add home and temp check

### DIFF
--- a/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
+++ b/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
@@ -32,22 +32,38 @@ gcode:
     {% else %}
         {% set z_safe = max_z - act_z %}
     {% endif %}
+    {%set min_extrude_temp = printer.configfile.settings["extruder"]["min_extrude_temp"]|int %}
+    {%set act_extrude_temp = printer.extruder.temperature|int %}
     ##### end of definitions #####
     SAVE_GCODE_STATE NAME=PAUSE_state
     BASE_PAUSE
     G91
-    G1 E-{E} F2100
-    G1 Z{z_safe} F900
-    G90
-    G1 X{x_park} Y{y_park} F6000
-  
+    {% if act_extrude_temp > min_extrude_temp %}
+      G1 E-{E} F2100
+    {% else %}
+      {action_respond_info("Extruder not hot enough")}
+    {% endif %}
+    {% if "xyz" in printer.toolhead.homed_axes %}
+      G1 Z{z_safe} F900
+      G90
+      G1 X{x_park} Y{y_park} F6000
+    {% else %}
+      {action_respond_info("Printer not homed")}
+    {% endif %} 
+    
 [gcode_macro RESUME]
 rename_existing: BASE_RESUME
 gcode:
     ##### read E from pause macro #####
     {% set E = printer["gcode_macro PAUSE"].extrude|float %}
+    {%set min_extrude_temp = printer.configfile.settings["extruder"]["min_extrude_temp"]|int %}
+    {%set act_extrude_temp = printer.extruder.temperature|int %}
     ##### end of definitions #####
-    G91
-    G1 E{E} F2100
+    {% if act_extrude_temp > min_extrude_temp %}
+      G91
+      G1 E{E} F2100
+    {% else %}
+      {action_respond_info("Extruder not hot enough")}
+    {% endif %}  
     RESTORE_GCODE_STATE NAME=PAUSE_state
     BASE_RESUME


### PR DESCRIPTION
add home and temperature check to the default macros. This will avoid errors if PAUSE or RESUME is executed while not homed or extruder below minimum temperature.

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com