### PR TITLE
macro: add description and change rename_existing

### DIFF
--- a/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
+++ b/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
@@ -6,15 +6,17 @@ path: /home/pi/gcode_files
 [display_status]
 
 [gcode_macro CANCEL_PRINT]
-rename_existing: BASE_CANCEL_PRINT
+description: Cancel the actual running print
+rename_existing: CANCEL_PRINT_BASE
 gcode:
     TURN_OFF_HEATERS
     CLEAR_PAUSE
     SDCARD_RESET_FILE
-    BASE_CANCEL_PRINT
+    CANCEL_PRINT_BASE
 
 [gcode_macro PAUSE]
-rename_existing: BASE_PAUSE
+description: Pause the actual running print
+rename_existing: PAUSE_BASE
 # change this if you need more or less extrusion
 variable_extrude: 1.0
 gcode:
@@ -36,7 +38,7 @@ gcode:
     {%set act_extrude_temp = printer.extruder.temperature|int %}
     ##### end of definitions #####
     SAVE_GCODE_STATE NAME=PAUSE_state
-    BASE_PAUSE
+    PAUSE_BASE
     G91
     {% if act_extrude_temp > min_extrude_temp %}
       G1 E-{E} F2100
@@ -52,7 +54,8 @@ gcode:
     {% endif %} 
     
 [gcode_macro RESUME]
-rename_existing: BASE_RESUME
+description: Resume the actual running print
+rename_existing: RESUME_BASE
 gcode:
     ##### read E from pause macro #####
     {% set E = printer["gcode_macro PAUSE"].extrude|float %}
@@ -66,4 +69,4 @@ gcode:
       {action_respond_info("Extruder not hot enough")}
     {% endif %}  
     RESTORE_GCODE_STATE NAME=PAUSE_state
-    BASE_RESUME
+    RESUME_BASE


### PR DESCRIPTION
Change the rename_existing name for a better sorting result at the help command. Also add a macro description for the new klipper description property  

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com