### PR TITLE
get VELOCITY parameter if specified and add it to RESUME_BASE

### DIFF
--- a/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
+++ b/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
@@ -61,6 +61,12 @@ gcode:
     {% set E = printer["gcode_macro PAUSE"].extrude|float %}
     {%set min_extrude_temp = printer.configfile.settings["extruder"]["min_extrude_temp"]|int %}
     {%set act_extrude_temp = printer.extruder.temperature|int %}
+    #### get VELOCITY parameter if specified ####
+    {% if 'VELOCITY' in params|upper %}
+      {% set get_params = ('VELOCITY=' + params.VELOCITY)  %}
+    {%else %}
+      {% set get_params = "" %}
+    {% endif %}
     ##### end of definitions #####
     {% if act_extrude_temp > min_extrude_temp %}
       G91
@@ -69,4 +75,4 @@ gcode:
       {action_respond_info("Extruder not hot enough")}
     {% endif %}  
     RESTORE_GCODE_STATE NAME=PAUSE_state
-    RESUME_BASE
+    RESUME_BASE {get_params}


### PR DESCRIPTION
This is added to support the specified parameter of the org klipper gcode command

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com