### PR TITLE
remove gcode state

### DIFF
--- a/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
+++ b/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
@@ -37,7 +37,6 @@ gcode:
     {%set min_extrude_temp = printer.configfile.settings["extruder"]["min_extrude_temp"]|int %}
     {%set act_extrude_temp = printer.extruder.temperature|int %}
     ##### end of definitions #####
-    SAVE_GCODE_STATE NAME=PAUSE_state
     PAUSE_BASE
     G91
     {% if act_extrude_temp > min_extrude_temp %}
@@ -68,5 +67,4 @@ gcode:
     {% else %}
       {action_respond_info("Extruder not hot enough")}
     {% endif %}  
-    RESTORE_GCODE_STATE NAME=PAUSE_state
     RESUME_BASE


### PR DESCRIPTION
remove the save and restore of the gcode state as it is already paar of the base macros

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com