### PR TITLE
add park to CANCEL_PRINT

### DIFF
--- a/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
+++ b/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
@@ -6,6 +6,11 @@
 #
 # Version 1.7
 
+# add [include mainsail.cfg] to your printer.cfg to include it to your printer.cfg
+# modify x_park, y_park, z_park_delta and extrude value at the macro _TOOLHEAD_PARK_PAUSE_CANCEL if needed
+
+# use variable_park: False at CANCEL_PRINT to disallow the parking move
+
 [virtual_sdcard]
 path: /home/pi/gcode_files
 
@@ -13,16 +18,13 @@ path: /home/pi/gcode_files
 
 [display_status]
 
-# add [include mainsail.cfg] to your printer.cfg to include it to your printer.cfg
-# modify x_park, y_park, z_park_delta and extrude value at the macro  _TOOLHEAD_PARK_PAUSE_CANCEL  if needed
-
 [gcode_macro CANCEL_PRINT]
 description: Cancel the actual running print
 rename_existing: CANCEL_PRINT_BASE
-variable_enable: True
+variable_park: True
 gcode:
-  ## Move head and retract only if not already in the pause state and enabled
-  {% if printer.pause_resume.is_paused|lower == 'false' and enable|lower 'true'%}
+  ## Move head and retract only if not already in the pause state and park set to true
+  {% if printer.pause_resume.is_paused|lower == 'false' and park|lower == 'true'%}
     _TOOLHEAD_PARK_PAUSE_CANCEL
   {% endif %}
   TURN_OFF_HEATERS
@@ -40,7 +42,7 @@ description: Resume the actual running print
 rename_existing: RESUME_BASE
 gcode:
   ##### read extrude from  _TOOLHEAD_PARK_PAUSE_CANCEL  macro #####
-  {% set extrude = printer["gcode_macro  _TOOLHEAD_PARK_PAUSE_CANCEL  "].extrude %}
+  {% set extrude = printer['gcode_macro _TOOLHEAD_PARK_PAUSE_CANCEL'].extrude %}
   #### get VELOCITY parameter if specified ####
   {% if 'VELOCITY' in params|upper %}
     {% set get_params = ('VELOCITY=' + params.VELOCITY)  %}


### PR DESCRIPTION
As discussed internally add an file header. 

Add the functionality to move the head to a park position using CANCEL_PRINT

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com