### PR TITLE
feat: disable apt-daily & apt-daily-upgrade timers/services

### DIFF
--- a/modules/generic/61-disable-apt-daily
+++ b/modules/generic/61-disable-apt-daily
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -xe
+export LC_ALL=C
+
+########################################
+# Functions and Basic Configuration    #
+########################################
+
+# Load common functions and set up cleanup trap
+source /common.sh
+install_cleanup_trap
+
+# Load additional configuration (e.g., BASE_USER)
+source /files/00-config
+
+########################################
+# Disable apt-daily &                  #
+# apt-daily-upgrade timer              #
+########################################
+
+systemctl_if_exists disable apt-daily.timer
+systemctl_if_exists disable apt-daily-upgrade.timer


### PR DESCRIPTION
This PR add a generic module to disable the timer for the apt-daily & apt-daily-upgrade timer to prevent "time too close" issues while printing and upgrading the system.

fixes #330 