### PR TITLE
refactor: use systemctl_if_exists in 10-config-raspberry

### DIFF
--- a/modules/raspberry/10-config-raspberry
+++ b/modules/raspberry/10-config-raspberry
@@ -60,10 +60,10 @@ fi
 # services                             #
 ########################################
 
-systemctl disable hciuart.service
-systemctl disable bluetooth.service
+systemctl_if_exists disable hciuart.service
+systemctl_if_exists disable bluetooth.service
 if ! grep "bookworm" /etc/os-release; then
-    systemctl disable bluealsa.service
+    systemctl_if_exists disable bluealsa.service
 fi
 
 ########################################


### PR DESCRIPTION
This PR just use `systemctl_if_exists` instead of `systemctl` in the `10-config-raspberry` module.