### PR TITLE
fix(headless_nm): fix reading SSID or PW with special chars

### DIFF
--- a/modules/generic/files/headless-nm/headless_nm
+++ b/modules/generic/files/headless-nm/headless_nm
@@ -45,7 +45,7 @@ log() {
 }
 
 get_value() {
-    local key="$1" line
+    local key="$1" line key_part val_part
 
     while IFS= read -r line; do
         # Skip comments, empty lines or lines without '='
@@ -72,7 +72,7 @@ get_value() {
 
         echo "$val_part"
         return 0
-    done < "${SETUPFILE}"
+    done < <(tac -- "$SETUPFILE")
 }
 
 trim_whitespace() {


### PR DESCRIPTION
This PR fix reading the headless_nm.txt file with special chars in the values. Before it was just "source" this file. This PR will refactor this part and read it as a text file and extract the values as strings.

This PR fixes #346 