### PR TITLE
fix(opi3lts): update configuration to enable i2c and UART alongside SPI

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -67,7 +67,7 @@
     MOUNT_PROC: 1
     MOUNT_SYS: 1
   special_modules:
-    - 20-opi-3lts-spi
+    - 20-opi-3lts
   rpi_json:
     name: "MainsailOS $VERSION$ - Orange Pi 3 LTS (64-bit)"
     description: "A port of Armbian with preinstalled Klipper/Moonraker/Mainsail for 3D printers"

--- a/modules/special/20-opi-3lts
+++ b/modules/special/20-opi-3lts
@@ -14,10 +14,10 @@ install_cleanup_trap
 source /files/00-config
 
 ########################################
-# Enable SPI in armbianEnv             #
+# Enable SPI, i2c & UART in armbianEnv #
 ########################################
 
-echo "overlays=spi-spidev1" >> "${ARMBIAN_CONFIG_TXT_FILE}"
+echo "overlays=i2c0 spi-spidev1 uart3" >> "${ARMBIAN_CONFIG_TXT_FILE}"
 
 ########################################
 # Enable spi-dev module                #

--- a/modules/special/20-opi-3lts
+++ b/modules/special/20-opi-3lts
@@ -17,6 +17,27 @@ source /files/00-config
 # Enable SPI, i2c & UART in armbianEnv #
 ########################################
 
+# i2c0 > /dev/i2c-0
+# - SDA: PD26 > Pin3
+# - SCL: PD25 > Pin5
+#
+# Klipper
+# i2c_bus: i2c.0
+
+# spi-spidev1 > /dev/spidev1.0
+# - MOSI: PH5 > Pin19
+# - MISO: PH6 > Pin21
+# - CLK:  PH4 > Pin23
+# - CS:   PH3 > Pin24
+#
+# Klipper
+# cs_pin: gpiochip1/gpio227
+# spi_bus: spidev1.0
+
+# uart3: /dev/ttyS3
+# - TX: PD23 > Pin8
+# - RX: PD24 > Pin10
+
 echo "overlays=i2c0 spi-spidev1 uart3" >> "${ARMBIAN_CONFIG_TXT_FILE}"
 
 ########################################


### PR DESCRIPTION
This PR enable i2c and uart on the Orangepi 3 LTS.