### PR TITLE
fix: fix building wheels on armhf images

### DIFF
--- a/modules/generic/51-moonraker
+++ b/modules/generic/51-moonraker
@@ -52,11 +52,21 @@ create_user_directories
 
 echo "Execute installer"
 pushd "moonraker" &> /dev/null || exit 1
-# Workaround: Disable pip build isolation to avoid Permission denied errors
-# during QEMU-emulated armhf builds. The QEMU aarch64->armhf emulation causes
-# mkdir failures inside pip's isolated build temp directories.
-sudo -u "${BASE_USER}" PIP_NO_BUILD_ISOLATION=1 HOME="/home/${BASE_USER}" \
-  ./scripts/install-moonraker.sh -s -z
+
+# Workaround for 32-bit ARM (armhf) builds:
+# Building pillow from source fails under QEMU aarch64->armhf emulation
+# (Permission denied in os.makedirs during build_clib).
+# Pre-install pillow via apt and create the venv with --system-site-packages
+# so moonraker's installer finds it already available and skips the build.
+# The installer skips venv creation if the directory already exists.
+if [ "$(dpkg --print-architecture)" = "armhf" ]; then
+  echo "armhf detected: pre-installing pillow via apt (QEMU build workaround)"
+  apt-get install --yes python3-pil
+  MOONRAKER_VENV="/home/${BASE_USER}/moonraker-env"
+  sudo -u "${BASE_USER}" python3 -m virtualenv --system-site-packages "${MOONRAKER_VENV}"
+fi
+
+sudo -u "${BASE_USER}" ./scripts/install-moonraker.sh -s -z
 popd &> /dev/null || exit 1
 
 ########################################

--- a/modules/generic/51-moonraker
+++ b/modules/generic/51-moonraker
@@ -55,7 +55,7 @@ pushd "moonraker" &> /dev/null || exit 1
 
 # Workaround for 32-bit ARM (armhf) builds:
 if [ "$(dpkg --print-architecture)" = "armhf" ]; then
-  echo "armhf detected: pre-installing pillow as root (QEMU build workaround)"
+  echo "armhf detected: pre-installing pillow"
   # Install pillow build dependencies before building from source
   apt-get install --yes libjpeg-dev zlib1g-dev
   MOONRAKER_VENV="/home/${BASE_USER}/moonraker-env"

--- a/modules/generic/51-moonraker
+++ b/modules/generic/51-moonraker
@@ -54,16 +54,12 @@ echo "Execute installer"
 pushd "moonraker" &> /dev/null || exit 1
 
 # Workaround for 32-bit ARM (armhf) builds:
-# Building pillow from source fails under QEMU aarch64->armhf emulation
-# (Permission denied in os.makedirs during build_clib).
-# Pre-install pillow via apt and create the venv with --system-site-packages
-# so moonraker's installer finds it already available and skips the build.
-# The installer skips venv creation if the directory already exists.
 if [ "$(dpkg --print-architecture)" = "armhf" ]; then
-  echo "armhf detected: pre-installing pillow via apt (QEMU build workaround)"
-  apt-get install --yes python3-pil
+  echo "armhf detected: pre-installing pillow as root (QEMU build workaround)"
   MOONRAKER_VENV="/home/${BASE_USER}/moonraker-env"
-  sudo -u "${BASE_USER}" python3 -m virtualenv --system-site-packages "${MOONRAKER_VENV}"
+  sudo -u "${BASE_USER}" python3 -m virtualenv "${MOONRAKER_VENV}"
+  "${MOONRAKER_VENV}/bin/pip" install "pillow<=12.1.0,>=9.5.0"
+  chown -R "${BASE_USER}":"${BASE_USER}" "${MOONRAKER_VENV}"
 fi
 
 sudo -u "${BASE_USER}" ./scripts/install-moonraker.sh -s -z

--- a/modules/generic/51-moonraker
+++ b/modules/generic/51-moonraker
@@ -52,7 +52,10 @@ create_user_directories
 
 echo "Execute installer"
 pushd "moonraker" &> /dev/null || exit 1
-sudo -u "${BASE_USER}" ./scripts/install-moonraker.sh -s -z
+# Ensure pip build temp directory is writable by BASE_USER
+export TMPDIR="/tmp"
+chmod 1777 /tmp
+sudo -u "${BASE_USER}" TMPDIR="/tmp" ./scripts/install-moonraker.sh -s -z
 popd &> /dev/null || exit 1
 
 ########################################

--- a/modules/generic/51-moonraker
+++ b/modules/generic/51-moonraker
@@ -52,10 +52,13 @@ create_user_directories
 
 echo "Execute installer"
 pushd "moonraker" &> /dev/null || exit 1
-# Ensure pip build temp directory is writable by BASE_USER
-export TMPDIR="/tmp"
-chmod 1777 /tmp
-sudo -u "${BASE_USER}" TMPDIR="/tmp" ./scripts/install-moonraker.sh -s -z
+# Create a user-owned temp directory for pip builds
+# Workaround for Permission denied errors in QEMU chroot builds
+USER_TMPDIR="/home/${BASE_USER}/.pip-tmp"
+mkdir -p "${USER_TMPDIR}"
+chown "${BASE_USER}":"${BASE_USER}" "${USER_TMPDIR}"
+sudo -u "${BASE_USER}" TMPDIR="${USER_TMPDIR}" HOME="/home/${BASE_USER}" ./scripts/install-moonraker.sh -s -z
+rm -rf "${USER_TMPDIR}"
 popd &> /dev/null || exit 1
 
 ########################################

--- a/modules/generic/51-moonraker
+++ b/modules/generic/51-moonraker
@@ -52,13 +52,11 @@ create_user_directories
 
 echo "Execute installer"
 pushd "moonraker" &> /dev/null || exit 1
-# Create a user-owned temp directory for pip builds
-# Workaround for Permission denied errors in QEMU chroot builds
-USER_TMPDIR="/home/${BASE_USER}/.pip-tmp"
-mkdir -p "${USER_TMPDIR}"
-chown "${BASE_USER}":"${BASE_USER}" "${USER_TMPDIR}"
-sudo -u "${BASE_USER}" TMPDIR="${USER_TMPDIR}" HOME="/home/${BASE_USER}" ./scripts/install-moonraker.sh -s -z
-rm -rf "${USER_TMPDIR}"
+# Workaround: Disable pip build isolation to avoid Permission denied errors
+# during QEMU-emulated armhf builds. The QEMU aarch64->armhf emulation causes
+# mkdir failures inside pip's isolated build temp directories.
+sudo -u "${BASE_USER}" PIP_NO_BUILD_ISOLATION=1 HOME="/home/${BASE_USER}" \
+  ./scripts/install-moonraker.sh -s -z
 popd &> /dev/null || exit 1
 
 ########################################

--- a/modules/generic/51-moonraker
+++ b/modules/generic/51-moonraker
@@ -56,6 +56,8 @@ pushd "moonraker" &> /dev/null || exit 1
 # Workaround for 32-bit ARM (armhf) builds:
 if [ "$(dpkg --print-architecture)" = "armhf" ]; then
   echo "armhf detected: pre-installing pillow as root (QEMU build workaround)"
+  # Install pillow build dependencies before building from source
+  apt-get install --yes libjpeg-dev zlib1g-dev
   MOONRAKER_VENV="/home/${BASE_USER}/moonraker-env"
   sudo -u "${BASE_USER}" python3 -m virtualenv "${MOONRAKER_VENV}"
   "${MOONRAKER_VENV}/bin/pip" install "pillow<=12.1.0,>=9.5.0"

--- a/modules/generic/51-moonraker
+++ b/modules/generic/51-moonraker
@@ -57,7 +57,7 @@ pushd "moonraker" &> /dev/null || exit 1
 if [ "$(dpkg --print-architecture)" = "armhf" ]; then
   echo "armhf detected: pre-installing pillow"
   # Install pillow build dependencies before building from source
-  apt-get install --yes libjpeg-dev zlib1g-dev
+  apt-get install --yes libjpeg-dev zlib1g-dev python3-virtualenv
   MOONRAKER_VENV="/home/${BASE_USER}/moonraker-env"
   sudo -u "${BASE_USER}" python3 -m virtualenv "${MOONRAKER_VENV}"
   "${MOONRAKER_VENV}/bin/pip" install "pillow<=12.1.0,>=9.5.0"


### PR DESCRIPTION
Building armhf (32-bit ARM) images fails during the Moonraker installation step. When pip tries to build pillow from source inside the QEMU-emulated chroot.

This is caused by a QEMU user-mode emulation bug: the host kernel is aarch64 but the target is armhf, and certain mkdir syscalls fail for non-root users under this cross-architecture emulation. The issue only affects armhf builds.

### Solution

For armhf builds only, pre-install pillow into the Moonraker virtualenv as root before running Moonraker's installer:

1. Install pillow's build dependencies (libjpeg-dev, zlib1g-dev)
2. Create the Moonraker virtualenv as the target user
3. Build and install pillow as root (bypassing the QEMU permission bug)
4. Fix ownership of the virtualenv back to the target user

All other architectures remain unaffected and use the normal installation path.