### PR TITLE
feat(trixie)!: upgrade base images to Debian Trixie

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,7 @@ jobs:
           scripts:  "${{ github.workspace }}/scripts"
           config: "${{ github.workspace }}/config.local"
           environment: '{ "RELEASE_TAG": "${{ env.RELEASE_TAG }}"}'
+          custopizer: "main"
 
       - name: "✏ Rename image"
         working-directory: ./build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
   build:
     needs: generate-matrix
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
 
   build:
     needs: [ prepare-release, generate-matrix ]
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,7 @@ jobs:
           scripts:  "${{ github.workspace }}/scripts"
           config: "${{ github.workspace }}/config.local"
           environment: '{ "RELEASE_TAG": "${{ env.RELEASE_TAG }}"}'
+          custopizer: "main"
 
       - name: "✏ Rename image"
         working-directory: ./build
@@ -259,6 +260,11 @@ jobs:
 
           # replace $VERSION$ in name
           rpi_data['name'] = rpi_data['name'].replace('$VERSION$', "${{ env.RELEASE_TAG }}")
+
+          # derive init_format from env.INIT_FORMAT, unless already set in rpi_json
+          env_init_format = matrix.get('env', {}).get('INIT_FORMAT', '')
+          if env_init_format and 'init_format' not in rpi_data:
+              rpi_data['init_format'] = env_init_format
 
           filename = "${{ env.IMAGE }}.xz"
           repo = "${{ github.repository }}"

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
-- name: raspberry_pi-armhf-bookworm
+- name: raspberry_pi-armhf-trixie
   type: raspberry
-  img_download_url: "https://downloads.raspberrypi.com/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2025-10-02/2025-10-01-raspios-bookworm-armhf-lite.img.xz.torrent"
-  img_hash_url: "https://downloads.raspberrypi.com/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2025-10-02/2025-10-01-raspios-bookworm-armhf-lite.img.xz.sha256"
+  img_download_url: "https://downloads.raspberrypi.org/raspios_lite_armhf_latest.torrent"
+  img_hash_url: "https://downloads.raspberrypi.org/raspios_lite_armhf_latest.sha256"
   env:
     ARCH: armhf
     IMAGE_ENLARGEROOT: 6000
@@ -17,10 +17,10 @@
       - "pi1-32bit"
       - "pi2-32bit"
 
-- name: raspberry_pi-arm64-bookworm
+- name: raspberry_pi-arm64-trixie
   type: raspberry
-  img_download_url: "https://downloads.raspberrypi.com/raspios_oldstable_lite_arm64/images/raspios_oldstable_lite_arm64-2025-10-02/2025-10-01-raspios-bookworm-arm64-lite.img.xz.torrent"
-  img_hash_url: "https://downloads.raspberrypi.com/raspios_oldstable_lite_arm64/images/raspios_oldstable_lite_arm64-2025-10-02/2025-10-01-raspios-bookworm-arm64-lite.img.xz.sha256"
+  img_download_url: "https://downloads.raspberrypi.org/raspios_lite_arm64_latest.torrent"
+  img_hash_url: "https://downloads.raspberrypi.org/raspios_lite_arm64_latest.sha256"
   env:
     ARCH: arm64
     IMAGE_ENLARGEROOT: 6000
@@ -37,10 +37,10 @@
       - "pi4-64bit"
       - "pi5-64bit"
 
-- name: armbian-orangepi4_lts-bookworm
+- name: armbian-orangepi4_lts-trixie
   type: armbian
-  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi4_lts_bookworm.img.xz"
-  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi4_lts_bookworm.img.xz.sha256"
+  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi4_lts_trixie.img.xz"
+  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi4_lts_trixie.img.xz.sha256"
   env:
     ARCH: arm64
     DISTRO: armbian
@@ -56,10 +56,10 @@
     devices:
       - "opi4-64bit"
 
-- name: armbian-orangepi3_lts-bookworm
+- name: armbian-orangepi3_lts-trixie
   type: armbian
-  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi3_lts_bookworm.img.xz"
-  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi3_lts_bookworm.img.xz.sha256"
+  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi3_lts_trixie.img.xz"
+  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi3_lts_trixie.img.xz.sha256"
   env:
     ARCH: arm64
     DISTRO: armbian
@@ -75,10 +75,10 @@
     devices:
       - "opi3-64bit"
 
-- name: armbian-orangepi_zero2-bookworm
+- name: armbian-orangepi_zero2-trixie
   type: armbian
-  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi_zero2_bookworm.img.xz"
-  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi_zero2_bookworm.img.xz.sha256"
+  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi_zero2_trixie.img.xz"
+  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi_zero2_trixie.img.xz.sha256"
   env:
     ARCH: arm64
     DISTRO: armbian
@@ -94,10 +94,10 @@
     devices:
       - "opizero2-64bit"
 
-- name: armbian-orangepi_zero3-bookworm
+- name: armbian-orangepi_zero3-trixie
   type: armbian
-  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi_zero3_bookworm.img.xz"
-  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi_zero3_bookworm.img.xz.sha256"
+  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi_zero3_trixie.img.xz"
+  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi_zero3_trixie.img.xz.sha256"
   env:
     ARCH: arm64
     DISTRO: armbian
@@ -113,12 +113,11 @@
     devices:
       - "opizero3-64bit"
 
-- name: armbian-btt_cb1-bookworm
+- name: armbian-btt_cb1-trixie
   type: armbian
   build_only: True
-  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-bigtreetech_cb1_bookworm.img.xz
-"
-  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-bigtreetech_cb1_bookworm.img.xz.sha256"
+  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-bigtreetech_cb1_trixie.img.xz"
+  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-bigtreetech_cb1_trixie.img.xz.sha256"
   env:
     ARCH: arm64
     DISTRO: armbian

--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,7 @@
   img_download_url: "https://downloads.raspberrypi.org/raspios_lite_armhf_latest.torrent"
   img_hash_url: "https://downloads.raspberrypi.org/raspios_lite_armhf_latest.sha256"
   env:
-    ARCH: armhf
+    ARCH: armv7l
     IMAGE_ENLARGEROOT: 6000
     MOUNT_PROC: 1
     MOUNT_SYS: 1

--- a/config.yml
+++ b/config.yml
@@ -7,12 +7,12 @@
     IMAGE_ENLARGEROOT: 6000
     MOUNT_PROC: 1
     MOUNT_SYS: 1
+    INIT_FORMAT: cloudinit-rpi
   special_modules: []
   rpi_json:
     name: "MainsailOS $VERSION$ - Raspberry Pi (32-bit)"
     description: "A port of Raspberry Pi OS with preinstalled Klipper/Moonraker/Mainsail for 3D printers"
     icon: "https://os.mainsail.xyz/rpi-imager.png"
-    init_format: "systemd"
     devices:
       - "pi1-32bit"
       - "pi2-32bit"
@@ -26,12 +26,12 @@
     IMAGE_ENLARGEROOT: 6000
     MOUNT_PROC: 1
     MOUNT_SYS: 1
+    INIT_FORMAT: cloudinit-rpi
   special_modules: []
   rpi_json:
     name: "MainsailOS $VERSION$ - Raspberry Pi (64-bit)"
     description: "A port of Raspberry Pi OS with preinstalled Klipper/Moonraker/Mainsail for 3D printers"
     icon: "https://os.mainsail.xyz/rpi-imager.png"
-    init_format: "systemd"
     devices:
       - "pi3-64bit"
       - "pi4-64bit"
@@ -47,6 +47,7 @@
     IMAGE_ENLARGEROOT: 5000
     MOUNT_PROC: 1
     MOUNT_SYS: 1
+    INIT_FORMAT: cloudinit
   special_modules:
     - 20-opi-4lts
   rpi_json:
@@ -66,6 +67,7 @@
     IMAGE_ENLARGEROOT: 5000
     MOUNT_PROC: 1
     MOUNT_SYS: 1
+    INIT_FORMAT: cloudinit
   special_modules:
     - 20-opi-3lts
   rpi_json:
@@ -85,6 +87,7 @@
     IMAGE_ENLARGEROOT: 5000
     MOUNT_PROC: 1
     MOUNT_SYS: 1
+    INIT_FORMAT: cloudinit
   special_modules:
     - 20-opi-zero2
   rpi_json:
@@ -104,6 +107,7 @@
     IMAGE_ENLARGEROOT: 5000
     MOUNT_PROC: 1
     MOUNT_SYS: 1
+    INIT_FORMAT: cloudinit
   special_modules:
     - 20-opi-zero3
   rpi_json:
@@ -124,6 +128,7 @@
     IMAGE_ENLARGEROOT: 5000
     MOUNT_PROC: 1
     MOUNT_SYS: 1
+    INIT_FORMAT: cloudinit
   rpi_json:
     name: "MainsailOS $VERSION$ - BigTreeTech CB1 (64-bit)"
     description: "A port of Armbian with preinstalled Klipper/Moonraker/Mainsail for 3D printers"

--- a/modules/armbian/13-armbian-cloudinit
+++ b/modules/armbian/13-armbian-cloudinit
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -xe
+export LC_ALL=C
+
+########################################
+# Functions and Basic Configuration    #
+########################################
+
+# Load common functions and set up cleanup trap
+source /common.sh
+install_cleanup_trap
+
+# Load additional configuration (e.g., BASE_USER)
+source /files/00-config
+
+########################################
+# Gate on INIT_FORMAT                  #
+########################################
+
+INIT_FORMAT="${EDITBASE_INIT_FORMAT:-}"
+case "${INIT_FORMAT}" in
+    cloudinit|cloudinit-rpi)
+        echo_green "Installing cloud-init on Armbian (INIT_FORMAT=${INIT_FORMAT})"
+        ;;
+    *)
+        echo "Skipping Armbian cloud-init module (INIT_FORMAT=${INIT_FORMAT:-unset})"
+        exit 0
+        ;;
+esac
+
+########################################
+# Install cloud-init                   #
+########################################
+
+# Armbian does not ship cloud-init by default. We install it and drop in a
+# NoCloud datasource override pointing at /boot (RPi Imager writes user-data
+# there on Armbian because Armbian mounts the boot partition directly under
+# /boot, not /boot/firmware).
+DEPS=(cloud-init python3-yaml)
+apt-get install --yes "${DEPS[@]}"
+
+########################################
+# Install NoCloud datasource override  #
+########################################
+
+install -m 0644 /files/cloudinit/99_mainsailos.cfg \
+    /etc/cloud/cloud.cfg.d/99_mainsailos.cfg
+
+########################################
+# Ship placeholder seed files          #
+########################################
+
+# Placeholders exist so cloud-init's NoCloud datasource does not error out on
+# an unmodified image; RPi Imager overwrites these when the user customises.
+install -m 0644 /files/cloudinit/meta-data      "${BOOT_PATH}/meta-data"
+install -m 0644 /files/cloudinit/user-data      "${BOOT_PATH}/user-data"
+install -m 0644 /files/cloudinit/network-config "${BOOT_PATH}/network-config"
+
+########################################
+# Disable armbian-firstrun-config      #
+########################################
+
+# armbian-firstrun-config conflicts with cloud-init (both try to configure
+# the system on first boot). Disable it so cloud-init owns that turf.
+systemctl_if_exists disable armbian-firstrun-config.service || true
+systemctl_if_exists mask    armbian-firstrun-config.service || true
+
+# Remove the firstrun template from /boot so armbian's machinery doesn't try
+# to read it anymore.
+rm -f "${BOOT_PATH}/armbian_first_run.txt" \
+      "${BOOT_PATH}/armbian_first_run.txt.template"

--- a/modules/armbian/files/cloudinit/99_mainsailos.cfg
+++ b/modules/armbian/files/cloudinit/99_mainsailos.cfg
@@ -1,0 +1,19 @@
+# Armbian does not ship rpi-cloud-init-mods, so MainsailOS configures the
+# NoCloud datasource by hand and points it at /boot (where RPi Imager and
+# compatible tooling drop meta-data / user-data / network-config).
+
+datasource_list: [ NoCloud, None ]
+datasource:
+  NoCloud:
+    seedfrom: file:///boot/
+
+# Let armbian-firstrun-config stay out of cloud-init's way; we disable the
+# service at build time (modules/armbian/13-armbian-cloudinit).
+
+# Don't regenerate SSH host keys via cloud-init - ssh.service handles that
+# on first boot already.
+ssh:
+  emit_keys_to_console: false
+no_ssh_fingerprints: true
+ssh_deletekeys: false
+ssh_genkeytypes: []

--- a/modules/armbian/files/cloudinit/meta-data
+++ b/modules/armbian/files/cloudinit/meta-data
@@ -1,0 +1,4 @@
+# cloud-init NoCloud meta-data placeholder shipped by MainsailOS.
+# RPi Imager (and any compatible tool) overwrites this file when the user
+# applies OS customisation, so we ship only a static instance-id.
+instance-id: mainsailos-armbian

--- a/modules/armbian/files/cloudinit/network-config
+++ b/modules/armbian/files/cloudinit/network-config
@@ -1,0 +1,4 @@
+# cloud-init network-config placeholder shipped by MainsailOS.
+# This file is overwritten by RPi Imager when WiFi credentials are supplied.
+# On an unmodified image we fall back to whatever network configuration the
+# base Armbian image ships with.

--- a/modules/armbian/files/cloudinit/user-data
+++ b/modules/armbian/files/cloudinit/user-data
@@ -1,0 +1,8 @@
+#cloud-config
+# cloud-init user-data placeholder shipped by MainsailOS.
+# This file is overwritten by RPi Imager (or any compatible tool) when the
+# user applies OS customisation; on an unmodified image it deliberately does
+# nothing so the pre-built "pi" user with its default password remains the
+# way to log in.
+#
+# See https://cloudinit.readthedocs.io/ for the full reference.

--- a/modules/generic/50-klipper
+++ b/modules/generic/50-klipper
@@ -35,8 +35,13 @@ DEPS=(git \
       stm32flash dfu-util libnewlib-arm-none-eabi \
       gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0-0 \
       # Input shaper dependencies
-      python3-numpy python3-matplotlib libatlas-base-dev libopenblas-dev \
+      python3-numpy python3-matplotlib libopenblas-dev \
       )
+
+# libatlas-base-dev was merged into libopenblas-dev in Trixie and is no longer available
+if [ "$(is_in_apt libatlas-base-dev)" -eq 1 ]; then
+  DEPS+=(libatlas-base-dev)
+fi
 
 ########################################
 # Install Dependencies                 #
@@ -81,7 +86,10 @@ sudo -u "${BASE_USER}" virtualenv -p python3 "${ENV_DIR}"
 echo "Installing Python Dependencies ..."
 sudo -u "${BASE_USER}" "${ENV_DIR}"/bin/pip install -r "${SRC_DIR}"/scripts/klippy-requirements.txt
 echo "Installing NumPy in Virtualenv"
-sudo -u "${BASE_USER}" "${ENV_DIR}"/bin/pip install "numpy<1.26"
+
+# Normally klipper would use "numpy<1.26", but that version does not support
+# Python 3.13 which is now in Debian Trixie.
+sudo -u "${BASE_USER}" "${ENV_DIR}"/bin/pip install "numpy"
 
 ########################################
 # Return to saved directory            #

--- a/modules/generic/53-crowsnest
+++ b/modules/generic/53-crowsnest
@@ -18,12 +18,7 @@ source /files/00-config
 ########################################
 
 REPO="https://github.com/mainsail-crew/crowsnest.git"
-DEPS=(git)
-
-INSTALL_SCRIPT="/home/${BASE_USER}/crowsnest/tools/libs/pkglist-generic.sh"
-if [[ "$(is_raspbian)" = "1" ]]; then
-    INSTALL_SCRIPT="/home/${BASE_USER}/crowsnest/tools/libs/pkglist-rpi.sh"
-fi
+DEPS=(git make)
 
 ########################################
 # Install System Packages              #
@@ -38,19 +33,6 @@ apt-get install --yes "${DEPS[@]}"
 pushd "/home/${BASE_USER}" &> /dev/null || exit 1
 sudo -u "${BASE_USER}" git clone ${REPO} crowsnest
 popd &> /dev/null || exit 1
-
-########################################
-# Installation Crowsnest Dependencies  #
-########################################
-
-PKGLIST=$(
-    # shellcheck disable=SC1090
-    source "$INSTALL_SCRIPT"
-    echo "$PKGLIST"
-)
-# convert string to array
-read -ra PKGARRAY <<< "$PKGLIST"
-apt-get install --yes "${PKGARRAY[@]}"
 
 ########################################
 # Installation Crowsnest               #

--- a/modules/generic/61-postrename-cloudinit
+++ b/modules/generic/61-postrename-cloudinit
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -xe
+export LC_ALL=C
+
+########################################
+# Functions and Basic Configuration    #
+########################################
+
+# Load common functions and set up cleanup trap
+source /common.sh
+install_cleanup_trap
+
+# Load additional configuration (e.g., BASE_USER)
+source /files/00-config
+
+########################################
+# Gate on INIT_FORMAT                  #
+########################################
+
+INIT_FORMAT="${EDITBASE_INIT_FORMAT:-systemd}"
+case "${INIT_FORMAT}" in
+    cloudinit|cloudinit-rpi)
+        echo_green "Installing cloud-init pre/post-rename services (INIT_FORMAT=${INIT_FORMAT})"
+        ;;
+    *)
+        echo "Skipping cloud-init post-rename setup (INIT_FORMAT=${INIT_FORMAT})"
+        exit 0
+        ;;
+esac
+
+########################################
+# Pick the correct boot path           #
+########################################
+
+# The service needs the boot FAT mounted before it can read user-data.
+if [[ "${BOOT_PATH}" == "/boot/firmware" ]]; then
+    BOOT_REQUIRE="/boot/firmware"
+else
+    BOOT_REQUIRE="/boot"
+fi
+
+########################################
+# Install dependencies                 #
+########################################
+
+DEPS=(python3-yaml cloud-init)
+apt-get install --yes "${DEPS[@]}"
+
+########################################
+# Install scripts & systemd units      #
+########################################
+
+install -d -m 0755 /usr/local/sbin /usr/local/lib/mainsailos /var/lib/mainsailos
+
+install -m 0755 /files/cloudinit/prerename /usr/local/sbin/mainsailos-prerename
+install -m 0755 /files/cloudinit/postrename /usr/local/sbin/mainsailos-postrename
+install -m 0644 /files/cloudinit/postrename-lib /usr/local/lib/mainsailos/postrename-lib
+
+install -m 0644 /files/cloudinit/mainsailos-prerename.service \
+    /etc/systemd/system/mainsailos-prerename.service
+install -m 0644 /files/cloudinit/mainsailos-postrename.service \
+    /etc/systemd/system/mainsailos-postrename.service
+
+# Substitute build-time placeholders in the installed files:
+#   @BOOT_REQUIRE@ - boot partition mount path (/boot vs /boot/firmware)
+#   @BASE_USER@   - pre-built default user that the prerename step will rename
+INSTALLED_FILES=(
+    /usr/local/sbin/mainsailos-prerename
+    /usr/local/sbin/mainsailos-postrename
+    /usr/local/lib/mainsailos/postrename-lib
+    /etc/systemd/system/mainsailos-prerename.service
+    /etc/systemd/system/mainsailos-postrename.service
+)
+for f in "${INSTALLED_FILES[@]}"; do
+    sed -i \
+        -e "s|@BOOT_REQUIRE@|${BOOT_REQUIRE}|g" \
+        -e "s|@BASE_USER@|${BASE_USER}|g" \
+        "${f}"
+done
+
+systemctl_if_exists enable mainsailos-prerename.service
+systemctl_if_exists enable mainsailos-postrename.service

--- a/modules/generic/files/00-config
+++ b/modules/generic/files/00-config
@@ -15,6 +15,7 @@ export HOLD_PKGS=(
 )
 
 export BASE_USER=pi
+export BASE_PASSWORD=raspberry
 export DIST_NAME=MainsailOS
 
 export PRINTER_DATA_DIRS="printer_data printer_data/config printer_data/comms printer_data/logs printer_data/systemd"

--- a/modules/generic/files/cloudinit/mainsailos-postrename.service
+++ b/modules/generic/files/cloudinit/mainsailos-postrename.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=MainsailOS post-rename (fix paths, services, venvs, polkit, symlinks after cloud-init)
+# cloud-init.target is ordered "After=multi-user.target", and cloud-final.service
+# is WantedBy=cloud-init.target — so cloud-final runs AFTER the rest of
+# multi-user.target is already up. We therefore hook into the same target as
+# cloud-final and explicitly wait for it, instead of WantedBy=multi-user.target
+# (which would race against cloud-final and silently drop the After= edge).
+After=cloud-final.service
+Wants=cloud-final.service
+ConditionPathExists=!/var/lib/mainsailos/postrename.done
+ConditionPathExists=/usr/local/sbin/mainsailos-postrename
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/mainsailos-postrename
+TimeoutStartSec=10min
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=cloud-init.target

--- a/modules/generic/files/cloudinit/mainsailos-prerename.service
+++ b/modules/generic/files/cloudinit/mainsailos-prerename.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=MainsailOS pre-rename (rename @BASE_USER@ -> custom user from user-data, before cloud-init)
+DefaultDependencies=no
+After=systemd-remount-fs.service local-fs.target
+# BOOT_REQUIRE is substituted at install time with "/boot/firmware" on RPi,
+# "/boot" on Armbian, so that the boot FAT is mounted before we parse user-data.
+RequiresMountsFor=@BOOT_REQUIRE@
+Before=cloud-init-local.service cloud-init.service cloud-init.target shutdown.target
+Conflicts=shutdown.target
+ConditionPathExists=!/var/lib/mainsailos/prerename.done
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/mainsailos-prerename
+StandardOutput=journal+console
+
+[Install]
+WantedBy=cloud-init.target

--- a/modules/generic/files/cloudinit/postrename
+++ b/modules/generic/files/cloudinit/postrename
@@ -1,0 +1,117 @@
+#!/bin/bash
+#### Post-rename for cloud-init based images
+####
+#### Copyright 2024 - till today
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+#### Runs After=cloud-final.service (paired with cloud-init.target). By that
+#### time cloud-init has applied user-data (groups, SSH keys, password). We now
+#### patch all paths/service-files/venvs/polkit/logrotate/symlinks that still
+#### point at /home/@BASE_USER@ so the rename from the prerename step becomes
+#### effective for every MainsailOS component.
+####
+#### Design notes:
+####  * NO `set -e` / `set -Ee` — handled by `run_step` in the shared library
+####    (every transform is logged and the loop continues on individual
+####    failures, mirroring the legacy rc.local variant).
+####  * STATE_FILE is only written on the explicit success path at the end
+####    of main. If the script dies mid-way (OOM, segfault in a transform,
+####    `set -u` on an unset var, power cut), the file stays absent, the
+####    systemd unit goes to `failed`, and the next boot will retry — which
+####    is the only safe behaviour because a half-migrated system has
+####    services running as the renamed user while nginx root / polkit /
+####    venv shebangs / env files may still point at @BASE_USER@.
+####  * `cleanup` is HARD: detach systemd units, remove unit files, remove
+####    /usr/local/sbin scripts and the shared library. The STATE_FILE under
+####    /var/lib/mainsailos stays as an audit marker.
+
+set -u
+export LC_ALL=C
+
+LIB="/usr/local/lib/mainsailos/postrename-lib"
+STATE_DIR="/var/lib/mainsailos"
+STATE_FILE="${STATE_DIR}/postrename.done"
+LOG_FILE="/var/log/mainsailos-postrename.log"
+SERVICE_NAME="mainsailos-postrename.service"
+PRERENAME_UNIT="mainsailos-prerename.service"
+SBIN_PRE="/usr/local/sbin/mainsailos-prerename"
+SBIN_POST="/usr/local/sbin/mainsailos-postrename"
+
+## Tee everything to both the journal (via service StandardOutput=) and a
+## persistent log file, so the user can inspect what happened even if the
+## journal is still volatile on the first boot.
+mkdir -p "${STATE_DIR}" "$(dirname "${LOG_FILE}")"
+exec > >(stdbuf -oL tee -a "${LOG_FILE}") 2>&1
+
+# shellcheck source=/dev/null
+source "${LIB}"
+
+## Log only — STATE_FILE is written on the explicit success path at the
+## end of main. Any non-zero / unexpected exit must leave STATE_FILE
+## absent so the unit stays `failed` and the next boot retries, instead
+## of silently locking in a half-migrated system.
+on_exit() {
+    local rc=$?
+    log "=== exit rc=${rc} ==="
+}
+trap on_exit EXIT
+
+cleanup() {
+    log "cleanup: detaching systemd units"
+    systemctl disable "${SERVICE_NAME}"   >/dev/null 2>&1 || true
+    systemctl disable "${PRERENAME_UNIT}" >/dev/null 2>&1 || true
+    rm -f "/etc/systemd/system/multi-user.target.wants/${SERVICE_NAME}" \
+          "/etc/systemd/system/cloud-init.target.wants/${SERVICE_NAME}" \
+          "/etc/systemd/system/cloud-init.target.wants/${PRERENAME_UNIT}"
+
+    log "cleanup: removing unit files"
+    rm -f "/etc/systemd/system/${SERVICE_NAME}" \
+          "/etc/systemd/system/${PRERENAME_UNIT}"
+
+    log "cleanup: removing scripts"
+    rm -f "${SBIN_PRE}" "${SBIN_POST}"
+
+    log "cleanup: removing shared library"
+    postrename_cleanup_lib
+
+    systemctl daemon-reload >/dev/null 2>&1 || true
+}
+
+check_skip() {
+    if [[ -f "${STATE_FILE}" ]]; then
+        log "already completed on a previous boot — running cleanup sweep"
+        cleanup
+        exit 0
+    fi
+
+    if [[ -z "${DEFAULT_USER:-}" ]] || [[ "${DEFAULT_USER}" == "@BASE_USER@" ]]; then
+        log "default user is '${DEFAULT_USER:-unset}' — nothing to rename, cleaning up"
+        touch "${STATE_FILE}"
+        cleanup
+        exit 0
+    fi
+}
+
+main() {
+    log "=== mainsailos-postrename starting ==="
+
+    check_skip
+
+    log "applying MainsailOS rename transforms for user '${DEFAULT_USER}'"
+    postrename_apply_all
+
+    log "all transforms applied — marking done, cleaning up, scheduling reboot"
+    touch "${STATE_FILE}"
+    cleanup
+
+    ## Schedule the reboot as an independent transient timer unit via systemd-run.
+    systemd-run --on-active=3s --timer-property=AccuracySec=1s \
+        --unit=mainsailos-reboot systemctl --no-wall reboot
+
+    log "=== mainsailos-postrename done ==="
+    exit 0
+}
+
+main

--- a/modules/generic/files/cloudinit/postrename-lib
+++ b/modules/generic/files/cloudinit/postrename-lib
@@ -1,0 +1,197 @@
+#!/bin/bash
+#### Post-rename common library
+####
+#### This library is sourced by both the legacy rc.local post-rename script
+#### (modules/raspberry/files/postrename) and the cloud-init post-rename
+#### wrapper (modules/generic/files/cloudinit/postrename).
+
+# shellcheck enable=require-variable-braces
+# shellcheck disable=SC2034  # variables exported for callers
+
+### Setup (variables are intentionally exported for callers)
+SERVICES=(moonraker klipper nginx sonar crowsnest)
+SYSTEMD_DIR="/etc/systemd/system"
+DEFAULT_USER="$(getent passwd 1000 | cut -d: -f1)"
+LIB_DIR="/usr/local/lib/mainsailos"
+LIB_FILE="${LIB_DIR}/postrename-lib"
+
+### KlipperScreen workaround
+if [[ -n "${DEFAULT_USER}" ]] && [[ -d "/home/${DEFAULT_USER}" ]]; then
+    KS_INSTALLED="$(find "/home/${DEFAULT_USER}" -maxdepth 1 -name "KlipperScreen" | wc -l)"
+else
+    KS_INSTALLED=0
+fi
+if [[ "${KS_INSTALLED}" = "1" ]]; then
+    SERVICES+=(KlipperScreen)
+fi
+
+log() { printf '%s\n' "$*"; }
+
+### Step wrapper: continue-on-error with structured logging.
+run_step() {
+    local name="$1"; shift
+    log "--- step: ${name} ---"
+    if "$@"; then
+        log "    OK: ${name}"
+    else
+        log "    FAILED: ${name} (rc=$?) — continuing"
+    fi
+}
+
+## Helper funcs
+### Mangle services
+stop_services() {
+    for srv in "${SERVICES[@]}"; do
+        if [[ "$(systemctl is-active "${srv}.service" 2>/dev/null)" != "inactive" ]]; then
+            systemctl stop "${srv}.service" 2>/dev/null || true
+        fi
+    done
+}
+
+start_services() {
+    for srv in "${SERVICES[@]}"; do
+        systemctl start "${srv}.service" 2>/dev/null || true
+    done
+}
+
+### Change nginx root
+change_www_root() {
+    if [[ -f /etc/nginx/sites-available/mainsail ]]; then
+        sed -i "s|/home/@BASE_USER@/mainsail|/home/${DEFAULT_USER}/mainsail|g" \
+            /etc/nginx/sites-available/mainsail
+    fi
+}
+
+### change username in service files
+change_service_user() {
+    ### Filter nginx service first!
+    local -a servicefile
+    servicefile=( "${SERVICES[@]/nginx}" )
+
+    for i in "${servicefile[@]}"; do
+        if [[ -n "${i}" && -f "${SYSTEMD_DIR}/${i}.service" ]]; then
+            sed -i "s/@BASE_USER@/${DEFAULT_USER}/g" "${SYSTEMD_DIR}/${i}.service"
+        fi
+    done
+}
+
+change_env_user() {
+    local env_files env_path
+    env_path="/home/${DEFAULT_USER}/printer_data/systemd"
+    [[ -d "${env_path}" ]] || return 0
+    env_files="$(find "${env_path}" -type f -name "*.env" -printf "%f ")"
+    for ef in ${env_files}; do
+        sed -i "s/@BASE_USER@/${DEFAULT_USER}/g" "${env_path}/${ef}"
+    done
+}
+
+relocate_venv() {
+    local -a venvs
+    venvs=(klippy-env moonraker-env crowsnest-env .KlipperScreen-env)
+
+    for venv in "${venvs[@]}"; do
+        [[ -d "/home/${DEFAULT_USER}/${venv}" ]] || continue
+
+        # delete pycache (*.pyc files)
+        find "/home/${DEFAULT_USER}/${venv}" -name "__pycache__" -type d -exec rm -rf {} +
+
+        # repair shebangs
+        while IFS= read -r file ; do
+            sed -i "s|@BASE_USER@/${venv}|${DEFAULT_USER}/${venv}|g" "${file}"
+        done < <(grep -iR "@BASE_USER@/${venv}" "/home/${DEFAULT_USER}/${venv}"/* 2>/dev/null | cut -d":" -f1 | sort -u)
+    done
+}
+
+patch_polkit_rules() {
+    local polkit_dir polkit_legacy_dir polkit_usr_dir
+    polkit_legacy_dir="/etc/polkit-1/localauthority/50-local.d"
+    polkit_dir="/etc/polkit-1/rules.d"
+    polkit_usr_dir="/usr/share/polkit-1/rules.d"
+    if [[ -f "${polkit_dir}/moonraker.rules" ]]; then
+        sed -i "s/@BASE_USER@/${DEFAULT_USER}/g" "${polkit_dir}/moonraker.rules"
+    fi
+    if [[ -f "${polkit_usr_dir}/moonraker.rules" ]]; then
+        sed -i "s/ \"@BASE_USER@\"/ \"${DEFAULT_USER}\"/g" "${polkit_usr_dir}/moonraker.rules"
+    fi
+    if [[ -f "${polkit_legacy_dir}/10-moonraker.pkla" ]]; then
+        sed -i "s/@BASE_USER@/${DEFAULT_USER}/g" "${polkit_legacy_dir}/10-moonraker.pkla"
+    fi
+    if [[ -f "${polkit_dir}/KlipperScreen.rules" ]]; then
+        sed -i "s/@BASE_USER@/${DEFAULT_USER}/g" "${polkit_dir}/KlipperScreen.rules"
+    fi
+    if [[ -f "${polkit_usr_dir}/KlipperScreen.rules" ]]; then
+        sed -i "s/@BASE_USER@/${DEFAULT_USER}/g" "${polkit_usr_dir}/KlipperScreen.rules"
+    fi
+    if [[ -f "${polkit_legacy_dir}/20-klipperscreen.pkla" ]]; then
+        sed -i "s/@BASE_USER@/${DEFAULT_USER}/g" "${polkit_legacy_dir}/20-klipperscreen.pkla"
+    fi
+}
+
+## Fix broken links
+fix_bin_links() {
+    local -a brokenlinks
+    local path
+    brokenlinks=(sonar)
+    path="/usr/local/bin"
+
+    for bl in "${brokenlinks[@]}"; do
+        if [[ -h "${path}/${bl}" ]]; then
+            rm -rf "${path:?}/${bl}"
+        fi
+        find "/home/${DEFAULT_USER}" -type f -iname "${bl}" -print0 | \
+            xargs -0 -I {} ln -s {} "${path}/${bl}"
+    done
+}
+
+fix_timelapse_links() {
+    local config_dir src_dir target_dir
+    config_dir="/home/${DEFAULT_USER}/printer_data/config"
+    src_dir="/home/${DEFAULT_USER}/moonraker-timelapse"
+    target_dir="/home/${DEFAULT_USER}/moonraker/moonraker/components"
+    [[ -d "${src_dir}" ]] || return 0
+    [[ -d "${target_dir}" ]] && sudo -u "${DEFAULT_USER}" \
+        ln -sf "${src_dir}/component/timelapse.py" "${target_dir}/timelapse.py"
+    [[ -d "${config_dir}" ]] && sudo -u "${DEFAULT_USER}" \
+        ln -sf "${src_dir}/klipper_macro/timelapse.cfg" "${config_dir}/timelapse.cfg"
+}
+
+fix_mainsailcfg_links() {
+    local config_dir src_dir
+    config_dir="/home/${DEFAULT_USER}/printer_data/config"
+    src_dir="/home/${DEFAULT_USER}/mainsail-config"
+    [[ -d "${src_dir}" && -d "${config_dir}" ]] || return 0
+    sudo -u "${DEFAULT_USER}" \
+        ln -sf "${src_dir}/mainsail.cfg" "${config_dir}/mainsail.cfg"
+}
+
+# Optional if kiauh module is used
+fix_kiauh_links() {
+    local src_dir target_dir
+    src_dir="/home/${DEFAULT_USER}/kiauh"
+    target_dir="/usr/local/bin"
+    [[ -d "${src_dir}" ]] || return 0
+    ln -sf "${src_dir}/kiauh.sh" "${target_dir}/kiauh"
+}
+
+### Apply all transforms via run_step (continue-on-error).
+postrename_apply_all() {
+    run_step "stop_services"           stop_services
+    run_step "change_www_root"         change_www_root
+    run_step "change_service_user"     change_service_user
+    run_step "change_env_user"         change_env_user
+    run_step "relocate_venv"           relocate_venv
+    run_step "patch_polkit_rules"      patch_polkit_rules
+    run_step "fix_bin_links"           fix_bin_links
+    run_step "fix_timelapse_links"     fix_timelapse_links
+    run_step "fix_mainsailcfg_links"   fix_mainsailcfg_links
+    run_step "fix_kiauh_links"         fix_kiauh_links
+    run_step "systemctl daemon-reload" systemctl daemon-reload
+    sleep 2
+    run_step "start_services"          start_services
+}
+
+### Self-cleanup of the shared library
+postrename_cleanup_lib() {
+    rm -f "${LIB_FILE}"
+    rmdir --ignore-fail-on-non-empty "${LIB_DIR}" 2>/dev/null || true
+}

--- a/modules/generic/files/cloudinit/prerename
+++ b/modules/generic/files/cloudinit/prerename
@@ -1,0 +1,174 @@
+#!/bin/bash
+#### Pre-rename for cloud-init based images
+####
+#### Runs Before=cloud-init-local.service and renames the default "@BASE_USER@"
+#### user to the one requested in /boot[/firmware]/user-data so cloud-init's
+#### users module then operates on the correct, pre-existing user.
+
+set -eu
+export LC_ALL=C
+
+LOG_TAG="mainsailos-prerename"
+STATE_DIR="/var/lib/mainsailos"
+STATE_FILE="${STATE_DIR}/prerename.done"
+USER_DATA_CANDIDATES=(/boot/firmware/user-data /boot/user-data)
+
+log() {
+    logger -s -t "${LOG_TAG}" -- "$*" || echo "${LOG_TAG}: $*"
+}
+
+find_userdata() {
+    local candidate
+    for candidate in "${USER_DATA_CANDIDATES[@]}"; do
+        if [[ -f "${candidate}" ]]; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+parse_user() {
+    python3 - "$1" <<'PY'
+import sys, yaml
+
+with open(sys.argv[1], "r") as fh:
+    data = yaml.safe_load(fh) or {}
+
+users = data.get("users")
+if not isinstance(users, list):
+    sys.exit(0)
+
+for user in users:
+    name = None
+    passwd = ""
+    lock = False
+
+    if isinstance(user, str):
+        name = user
+    elif isinstance(user, dict):
+        name = user.get("name")
+        passwd = user.get("passwd") or ""
+        lock = bool(user.get("lock_passwd", False))
+
+    if name and name not in ("default", "@BASE_USER@"):
+        print(name)
+        print(passwd)
+        print("true" if lock else "false")
+        sys.exit(0)
+PY
+}
+
+load_requested_user() {
+    local userdata="$1"
+    local parsed_user parse_rc
+
+    log "parsing user-data at ${userdata}"
+
+    set +e
+    parsed_user="$(parse_user "${userdata}")"
+    parse_rc=$?
+    set -e
+
+    if [[ ${parse_rc} -ne 0 ]]; then
+        log "ERROR: failed to parse ${userdata} (python exit ${parse_rc}); refusing to rename '@BASE_USER@' -- fix the user-data and reboot"
+        exit 1
+    fi
+
+    mapfile -t USER_FIELDS <<< "${parsed_user}"
+
+    NEW_USER="$(printf '%s' "${USER_FIELDS[0]:-}" | tr -d '[:space:]')"
+    NEW_PASSWD="${USER_FIELDS[1]:-}"
+    NEW_LOCK_PASSWD="${USER_FIELDS[2]:-false}"
+}
+
+nothing_to_rename() {
+    if [[ -z "${NEW_USER}" ]]; then
+        log "user-data keeps '@BASE_USER@' (or has no custom user), nothing to rename"
+        return 0
+    fi
+
+    if ! id -u @BASE_USER@ >/dev/null 2>&1; then
+        log "no '@BASE_USER@' user present, nothing to rename"
+        return 0
+    fi
+
+    if ! [[ "${NEW_USER}" =~ ^[a-z_][a-z0-9_-]*[$]?$ ]]; then
+        log "invalid username '${NEW_USER}', nothing to rename"
+        return 0
+    fi
+
+    if id -u "${NEW_USER}" >/dev/null 2>&1; then
+        log "target user '${NEW_USER}' already exists, leaving system untouched"
+        return 0
+    fi
+
+    return 1
+}
+
+rename_user() {
+    log "renaming '@BASE_USER@' to '${NEW_USER}' (home: /home/${NEW_USER})"
+
+    usermod -l "${NEW_USER}" @BASE_USER@
+
+    if getent group @BASE_USER@ >/dev/null 2>&1; then
+        groupmod -n "${NEW_USER}" @BASE_USER@
+    fi
+
+    if [[ -d /home/@BASE_USER@ ]]; then
+        usermod -d "/home/${NEW_USER}" -m "${NEW_USER}"
+    else
+        usermod -d "/home/${NEW_USER}" "${NEW_USER}"
+    fi
+}
+
+apply_password() {
+    if [[ -n "${NEW_PASSWD}" && "${NEW_LOCK_PASSWD}" != "true" ]]; then
+        log "applying passwd hash from user-data for '${NEW_USER}'"
+        usermod -p "${NEW_PASSWD}" "${NEW_USER}"
+    fi
+}
+
+update_sudoers() {
+    local old_file="/etc/sudoers.d/010_@BASE_USER@-nopasswd"
+    local new_file="/etc/sudoers.d/010_${NEW_USER}-nopasswd"
+
+    if [[ -f "${old_file}" ]]; then
+        mv "${old_file}" "${new_file}"
+        sed -i "s/^@BASE_USER@ /${NEW_USER} /" "${new_file}"
+        chmod 0440 "${new_file}"
+    fi
+}
+
+main() {
+    mkdir -p "${STATE_DIR}"
+    if [[ -f "${STATE_FILE}" ]]; then
+        log "already completed, nothing to do"
+        exit 0
+    fi
+
+    local userdata
+    userdata="$(find_userdata)"
+    if [[ -z "${userdata}" ]]; then
+        log "no user-data found, nothing to do"
+        touch "${STATE_FILE}"
+        exit 0
+    fi
+
+    load_requested_user "${userdata}"
+    if nothing_to_rename; then
+        touch "${STATE_FILE}"
+        exit 0
+    fi
+
+    rename_user
+    apply_password
+    update_sudoers
+
+    touch "${STATE_FILE}"
+    log "rename complete; cloud-init will configure '${NEW_USER}' next"
+
+    exit 0
+}
+
+main

--- a/modules/raspberry/10-config-raspberry
+++ b/modules/raspberry/10-config-raspberry
@@ -17,7 +17,10 @@ source /files/00-config
 # Configuration & Install deps         #
 ########################################
 
+# Legacy swap backend (dphys-swapfile) - used on Bookworm and older
 SWAP_CONF_FILE="/etc/dphys-swapfile"
+# Modern swap backend (rpi-swap) - used on Trixie and newer.
+RPI_SWAP_DROP_IN="/etc/rpi/swap.conf.d/10-mainsailos.conf"
 SWAP_SIZE="256"
 SWAP_MAX="1024"
 
@@ -70,8 +73,65 @@ fi
 # Increase swapfile size               #
 ########################################
 
-if [[ -f "${PICONFIG_SWAP_CONF_FILE}" ]]; then
-    echo_green "Increasing swap file size to ${SWAP_SIZE} Mb. Limit to ${SWAP_MAX} Mb"
+# Raspberry Pi OS Trixie replaced dphys-swapfile with rpi-swap.
+if [[ -f "${SWAP_CONF_FILE}" ]]; then
+    # Legacy: dphys-swapfile (Bookworm and older)
+    echo_green "Configuring swap (dphys-swapfile): ${SWAP_SIZE} MB, max ${SWAP_MAX} MB"
     sed -i 's/^CONF_SWAPSIZE.*/'CONF_SWAPSIZE="${SWAP_SIZE}"'/' "${SWAP_CONF_FILE}"
     sed -i 's/^#CONF_MAXSWAP.*/'CONF_MAXSWAP="${SWAP_MAX}"'/' "${SWAP_CONF_FILE}"
+elif dpkg-query -s rpi-swap &>/dev/null; then
+    # Modern: rpi-swap (Trixie and newer)
+    echo_green "Configuring swap (rpi-swap): ${SWAP_SIZE} MiB, max ${SWAP_MAX} MiB"
+    mkdir -p "$(dirname "${RPI_SWAP_DROP_IN}")"
+    cat > "${RPI_SWAP_DROP_IN}" <<EOF
+# Managed by MainsailOS build - swap size tuning
+[File]
+FixedSizeMiB=${SWAP_SIZE}
+MaxSizeMiB=${SWAP_MAX}
+EOF
+fi
+
+########################################
+# Finalize user setup and set password #
+########################################
+
+if [ -f /usr/lib/userconf-pi/userconf ]; then
+    hash="$(echo "$BASE_PASSWORD" | openssl passwd -6 -stdin)"
+    /usr/lib/userconf-pi/userconf "$BASE_USER" "${hash}"
+fi
+
+systemctl_if_exists disable userconfig.service
+
+########################################
+# Enable getty                         #
+########################################
+
+systemctl_if_exists enable getty@tty1.service
+
+########################################
+# Enable sshd                          #
+########################################
+
+if [ -f /usr/lib/raspberrypi-sys-mods/imager_custom ]; then
+    /usr/lib/raspberrypi-sys-mods/imager_custom enable_ssh
+else
+    systemctl_if_exists enable ssh
+fi
+
+########################################
+# Enable passwordless sudo (build)     #
+########################################
+
+# Trixie+: raspberrypi-sys-mods no longer ships /etc/sudoers.d/010_${BASE_USER}-nopasswd
+# Bookworm and earlier: /etc/sudoers.d/010_${BASE_USER}-nopasswd may already exist
+#
+# 98-remove-passwordless-sudo reverts both cases at the end of the build.
+RASPI_CONFIG="$(command -v raspi-config || true)"
+if [ -n "${RASPI_CONFIG}" ] && grep -q "^do_sudo_pass" "${RASPI_CONFIG}"; then
+    SUDO_USER="${BASE_USER}" raspi-config nonint do_sudo_pass 1
+elif [ ! -f "/etc/sudoers.d/010_${BASE_USER}-nopasswd" ]; then
+    # Fallback for legacy images that neither have the raspi-config
+    # helper nor the pre-shipped nopasswd file.
+    echo "${BASE_USER} ALL=(ALL) NOPASSWD: ALL" > "/etc/sudoers.d/010_${BASE_USER}-nopasswd"
+    chmod 440 "/etc/sudoers.d/010_${BASE_USER}-nopasswd"
 fi

--- a/modules/raspberry/61-postrename
+++ b/modules/raspberry/61-postrename
@@ -14,11 +14,44 @@ install_cleanup_trap
 source /files/00-config
 
 ########################################
-# Copy script & set user rights        #
+# Gate on INIT_FORMAT                  #
 ########################################
 
-cp /files/postrename /postrename
-chmod 0755 /postrename
+# This module installs the legacy rc.local-based post-rename hook that is
+# paired with the RPi-Imager "systemd" init_format (firstrun.sh). When the
+# image uses the cloud-init flow instead, the post-rename service is installed
+# by modules/generic/61-postrename-cloudinit, so we skip this one.
+INIT_FORMAT="${EDITBASE_INIT_FORMAT:-systemd}"
+case "${INIT_FORMAT}" in
+    cloudinit|cloudinit-rpi)
+        echo "Skipping legacy rc.local post-rename hook (INIT_FORMAT=${INIT_FORMAT})"
+        exit 0
+        ;;
+esac
+
+########################################
+# Install script + shared lib          #
+########################################
+
+# The rename transforms are shared with the cloud-init variant and live in
+# modules/generic/files/cloudinit/postrename-lib. Install it to the same
+# canonical path the cloud-init flow uses so both entry points source the
+# exact same code.
+install -d -m 0755 /usr/local/lib/mainsailos
+
+install -m 0755 /files/postrename /postrename
+install -m 0644 /files/cloudinit/postrename-lib \
+    /usr/local/lib/mainsailos/postrename-lib
+
+# Substitute build-time placeholders:
+#   @BASE_USER@ - pre-built default user that firstrun.sh will rename
+INSTALLED_FILES=(
+    /postrename
+    /usr/local/lib/mainsailos/postrename-lib
+)
+for f in "${INSTALLED_FILES[@]}"; do
+    sed -i "s|@BASE_USER@|${BASE_USER}|g" "${f}"
+done
 
 ########################################
 # Create rc.local, if it doesnt exists #

--- a/modules/raspberry/98-remove-passwordless-sudo
+++ b/modules/raspberry/98-remove-passwordless-sudo
@@ -17,6 +17,13 @@ source /files/00-config
 # Remove passwordless sudo access      #
 ########################################
 
-if [ -f /etc/sudoers.d/010_pi-nopasswd ]; then
-    sed -e '/^'"${BASE_USER}"'/ s/^#*/#/' -i /etc/sudoers.d/010_pi-nopasswd
+# Prefer the raspi-config helper. Available on Raspberry Pi OS Trixie and newer
+RASPI_CONFIG="$(command -v raspi-config || true)"
+if [ -n "${RASPI_CONFIG}" ] && grep -q "^do_sudo_pass" "${RASPI_CONFIG}"; then
+    SUDO_USER="${BASE_USER}" raspi-config nonint do_sudo_pass 0
+fi
+
+# Legacy fallback for older base images (Bookworm and earlier)
+if [ -f "/etc/sudoers.d/010_${BASE_USER}-nopasswd" ]; then
+    sed -e '/^'"${BASE_USER}"'/ s/^#*/#/' -i "/etc/sudoers.d/010_${BASE_USER}-nopasswd"
 fi

--- a/modules/raspberry/files/postrename
+++ b/modules/raspberry/files/postrename
@@ -1,5 +1,5 @@
 #!/bin/bash
-#### Post Rename
+#### Post Rename (legacy rc.local hook)
 ####
 #### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
 #### Copyright 2021
@@ -7,14 +7,19 @@
 ####
 #### This File is distributed under GPLv3
 ####
+#### Runs from /etc/rc.local on the first boot after RPi-Imager's firstrun.sh
+#### has renamed the default user. All rename transforms (service files, env
+#### files, venv shebangs, polkit, nginx root, symlinks, …) live in the
+#### shared library and are kept in sync with the cloud-init variant:
+####     /usr/local/lib/mainsailos/postrename-lib
+####
+#### This script only holds the legacy-specific bits:
+####   * gate on sdcard-resize / firstrun completion via cmdline.txt,
+####   * skip path when the default user is still the build-time @BASE_USER@,
+####   * self-destruct + rc.local entry removal at the end,
+####   * final reboot.
 
 # shellcheck enable=require-variable-braces
-
-## Error handling
-set -Ee
-
-# Debug
-# set -x
 
 ## Set LC_ALL to prevent errors
 export LC_ALL=C
@@ -26,267 +31,81 @@ GRE="\e[32m"
 WHITE="\e[97m"
 NOC="\e[0m"
 
-### Setup
-SERVICES=(moonraker klipper nginx sonar crowsnest)
-SYSTEMD_DIR="/etc/systemd/system"
-DEFAULT_USER="$(grep "1000" /etc/passwd | awk -F ':' '{print $1}')"
+LIB="/usr/local/lib/mainsailos/postrename-lib"
 
-### KlipperScreen workaround
-KS_INSTALLED="$(find /home/"${DEFAULT_USER}" -name "KlipperScreen" | wc -l)"
-if [[ "${KS_INSTALLED}" = "1" ]]; then
-    SERVICES+=(KlipperScreen)
+if [[ ! -f "${LIB}" ]]; then
+    echo -e "[${RED}ERROR${NOC}] ${WHITE}missing library ${LIB}${NOC}" >&2
+    exit 1
 fi
 
-## Helper funcs
-### Mangle services
-stop_services() {
-    for srv in "${SERVICES[@]}"; do
-        if [[ "$(systemctl is-active "${srv}.service")" != "inactive" ]]; then
-            systemctl stop "${srv}.service"
-        fi
-    done
+# shellcheck source=/dev/null
+source "${LIB}"
+
+check_skip() {
+    local cmdltxt
+
+    ## Boot partition is mounted under /boot/firmware since Bookworm;
+    ## older Raspberry Pi OS releases mounted it under /boot.
+    if [[ -f "/boot/firmware/cmdline.txt" ]]; then
+        cmdltxt="/boot/firmware/cmdline.txt"
+    else
+        cmdltxt="/boot/cmdline.txt"
+    fi
+
+    ## Make sure sdcard resize and first-boot provisioning are finished.
+    ## Bookworm and earlier: cmdline.txt contains `init=.../firstboot` and
+    ##                       `systemd.run=.../firstrun.sh` until both finish.
+    ## Trixie and later:     cmdline.txt contains the `resize` keyword which
+    ##                       is removed by the initramfs once resize completed.
+    if { grep -Eq 'init=[^[:space:]]*firstboot' "${cmdltxt}" \
+         && grep -q 'systemd.run=' "${cmdltxt}"; } \
+       || grep -Eq '(^|[[:space:]])resize([[:space:]]|$)' "${cmdltxt}"; then
+        echo -e "[${RED}ERROR${NOC}] \
+        ${WHITE}Sdcard resize and firstrun are not finished yet ... [ABORT]${NOC}"
+        ## Make sure not failing rc.local
+        return 0
+    fi
+
+    ## Abort if user is still the build-time base user (no rename happened)
+    ## @BASE_USER@ is substituted at build time (see modules/raspberry/61-postrename).
+    if [[ "${DEFAULT_USER}" == "@BASE_USER@" ]]; then
+        echo -e "[${YEL}SKIPPED${NOC}] \
+        ${WHITE}User is ${DEFAULT_USER}! Nothing to do ...${NOC}"
+        cleanup
+        exit 0
+    fi
 }
 
-start_services() {
-    for srv in "${SERVICES[@]}"; do
-        systemctl start "${srv}.service"
-    done
-}
-
-### Clean up
 cleanup() {
+    echo -e "${WHITE}Cleanup files, remove postrename ...${NOC}"
     # Cleanup self
     rm -rf "${0}"
-    # Cleanup rc.local
+    postrename_cleanup_lib
+    # Cleanup rc.local entry
     sed -i '/\/postrename/d' /etc/rc.local
+    sleep 2
 }
 
-### Change nginx root
-change_www_root() {
-    bash -c "
-        sed -i 's|/home/pi/mainsail|/home/${DEFAULT_USER}/mainsail|g' \
-        /etc/nginx/sites-available/mainsail
-    "
-}
+postrename() {
+    echo -e "\n\t${WHITE}Trying to fix user rename ...${NOC}"
+    ## Apply all transforms (stop services, patch files, restart services).
+    postrename_apply_all
 
-### change username in service files
-change_service_user() {
-    ### Filter nginx service first!
-    local -a servicefile
-    servicefile=( "${SERVICES[@]/nginx}" )
-
-    for i in "${servicefile[@]}"; do
-        if [[ -n "${i}" ]]; then
-        sed -i 's/pi/'"${DEFAULT_USER}"'/g' "${SYSTEMD_DIR}/${i}.service"
-        fi
-    done
-}
-
-change_env_user() {
-    local env_files env_path
-    env_path="/home/${DEFAULT_USER}/printer_data/systemd"
-    env_files="$(find "${env_path}" -type f -name "*.env" -printf "%f ")"
-    for ef in ${env_files}; do
-        sed -i 's/pi/'"${DEFAULT_USER}"'/g' "${env_path}/${ef}"
-    done
-}
-
-relocate_venv() {
-    local -a venvs
-    venvs=(klippy-env moonraker-env)
-
-    ### KlipperScreen workaround
-    if [[ "${KS_INSTALLED}" = "1" ]]; then
-        venvs+=(.KlipperScreen-env)
-    fi
-
-    for venv in "${venvs[@]}"; do
-        # Move venv
-        # delete pycache (*.pyc files)
-        find "/home/${DEFAULT_USER}/${venv}" -name "__pycache__" -type d -exec rm -rf {} +
-
-        # repair shebangs
-        while IFS= read -r file ; do
-            sed -i 's|pi/'"${venv}"'|'"${DEFAULT_USER}"'/'"${venv}"'|g' "${file}"
-        done < <(grep -iR "pi/${venv}" "/home/${DEFAULT_USER}/${venv}"/* | cut -d":" -f1)
-    done
-}
-
-patch_polkit_rules() {
-    local polkit_dir polkit_legacy_dir polkit_usr_dir
-    polkit_legacy_dir="/etc/polkit-1/localauthority/50-local.d"
-    polkit_dir="/etc/polkit-1/rules.d"
-    polkit_usr_dir="/usr/share/polkit-1/rules.d"
-    if [[ -f "${polkit_dir}/moonraker.rules" ]]; then
-        sed -i 's/pi/'"${DEFAULT_USER}"'/g' "${polkit_dir}/moonraker.rules"
-    fi
-    if [[ -f "${polkit_usr_dir}/moonraker.rules" ]]; then
-        sed -i 's/ "pi"/ \"'"${DEFAULT_USER}"'\"/g' "${polkit_usr_dir}/moonraker.rules"
-    fi
-    if [[ -f "${polkit_legacy_dir}/10-moonraker.pkla" ]]; then
-        sed -i 's/pi/'"${DEFAULT_USER}"'/g' "${polkit_legacy_dir}/10-moonraker.pkla"
-    fi
-    if [[ -f "${polkit_dir}/KlipperScreen.rules" ]]; then
-        sed -i 's/pi/'"${DEFAULT_USER}"'/g' "${polkit_dir}/KlipperScreen.rules"
-    fi
-    if [[ -f "${polkit_usr_dir}/KlipperScreen.rules" ]]; then
-        sed -i 's/pi/'"${DEFAULT_USER}"'/g' "${polkit_usr_dir}/KlipperScreen.rules"
-    fi
-    if [[ -f "${polkit_legacy_dir}/20-klipperscreen.pkla" ]]; then
-        sed -i 's/pi/'"${DEFAULT_USER}"'/g' "${polkit_legacy_dir}/20-klipperscreen.pkla"
-    fi
-}
-
-patch_cn_logpath() {
-    bash -c "
-        sed -i 's|/home/pi/printer_data/logs/crowsnest.log|/home/${DEFAULT_USER}/printer_data/logs/crowsnest.log|g' \
-        /home/${DEFAULT_USER}/printer_data/config/crowsnest.conf
-    "
-}
-
-patch_cn_logrotate() {
-    if [[ -f "/etc/logrotate.d/crowsnest" ]]; then
-        sed -i 's/pi/'"${DEFAULT_USER}"'/g' "/etc/logrotate.d/crowsnest"
-    fi
-}
-
-## Fix broken links
-fix_broken_links() {
-    local -a brokenlinks
-    local path
-    brokenlinks=(crowsnest sonar)
-    path="/usr/local/bin"
-
-    for bl in "${brokenlinks[@]}"; do
-        if [[ -h "${path}/${bl}" ]]; then
-            rm -rf "${path:?}/${bl}"
-        fi
-        find "/home/${DEFAULT_USER}" -type f -iname "${bl}" -print0 | \
-        xargs -0 -I {} ln -s {} "${path}/${bl}"
-    done
-}
-
-fix_timelapse_links() {
-    local config_dir src_dir target_dir
-    config_dir="/home/${DEFAULT_USER}/printer_data/config"
-    src_dir="/home/${DEFAULT_USER}/moonraker-timelapse"
-    target_dir="/home/${DEFAULT_USER}/moonraker/moonraker/components"
-    sudo -u "${DEFAULT_USER}" \
-    ln -sf "${src_dir}/component/timelapse.py" "${target_dir}/timelapse.py"
-    sudo -u "${DEFAULT_USER}" \
-    ln -sf "${src_dir}/klipper_macro/timelapse.cfg" "${config_dir}/timelapse.cfg"
-}
-
-fix_mainsailcfg_links() {
-    local config_dir src_dir target_dir
-    config_dir="/home/${DEFAULT_USER}/printer_data/config"
-    src_dir="/home/${DEFAULT_USER}/mainsail-config"
-    sudo -u "${DEFAULT_USER}" \
-    ln -sf "${src_dir}/mainsail.cfg" "${config_dir}/mainsail.cfg"
-}
-
-# Optional if kiauh module is used
-fix_kiauh_links() {
-    local src_dir target_dir
-    src_dir="/home/${DEFAULT_USER}/kiauh"
-    target_dir="/usr/local/bin"
-    ln -sf "${src_dir}/kiauh.sh" "${target_dir}/kiauh"
-}
-
-fix_cn_links() {
-    local tools_dir
-    tools_dir="/home/${DEFAULT_USER}/crowsnest/tools"
-    sudo -u "${DEFAULT_USER}" \
-    ln -sf "${tools_dir}/libs/pkglist-rpi.sh" "${tools_dir}/pkglist.sh"
+    ## wait 30sec to come up
+    echo -e "${WHITE}Waiting 30 seconds for service restart completed ...${NOC}"
+    sleep 30
 }
 
 main() {
-local cmdltxt
-cmdltxt="/boot/cmdline.txt"
+    check_skip
 
-## Make sure init_resize.sh and firstrun.sh are finished
-if [[ "$(grep -c "init" "${cmdltxt}")" != "0" ]] && \
-[[ "$(grep -c "systemd.run.*" "${cmdltxt}")" != "0" ]]; then
-    echo -e "[${RED}ERROR${NOC}] \
-    ${WHITE}Sdcard resize and firstrun are not finished yet ... [ABORT]${NOC}"
-    ## Make sure not failing rc.local
-    return 0
-fi
-## Abort if user = pi
-if [[ "${DEFAULT_USER}" == "pi" ]]; then
-    echo -e "[${YEL}SKIPPED${NOC}] \
-    ${WHITE}User is ${DEFAULT_USER}! Nothing to do ...${NOC}"
+    postrename
     cleanup
-    exit 0
-fi
 
-echo -e "\n\t${WHITE}Trying to fix user rename ...${NOC}"
-## Stop services
-echo -en "${WHITE}Stopping all related services ...${NOC}\r"
-stop_services
-echo -e "${WHITE}Stopping all related services ...${NOC}[${GRE}OK${NOC}]"
-## Change www root
-echo -en "${WHITE}Try changing path of nginx root ...${NOC}\r"
-change_www_root
-echo -e "${WHITE}Try changing path of nginx root ...${NOC}[${GRE}OK${NOC}]"
-## patch service files
-echo -en "${WHITE}Patching service files ...${NOC}\r"
-change_service_user
-echo -e "${WHITE}Patching service files ...${NOC}[${GRE}OK${NOC}]"
-## patch env files
-echo -en "${WHITE}Patching environment files ...${NOC}\r"
-change_env_user
-echo -e "${WHITE}Patching environment files ...${NOC}[${GRE}OK${NOC}]"
-## relocate venvs
-echo -e "${WHITE}Trying to relocate venv's ...${NOC}"
-relocate_venv
-echo -e "${WHITE}Trying to relocate venv's ...${NOC}[${GRE}OK${NOC}]"
-## patch polkit rules
-echo -e "${WHITE}Patching moonraker's polkit rules ...${NOC}"
-patch_polkit_rules
-echo -e "${WHITE}Patching moonraker's polkit rules ...${NOC}[${GRE}OK${NOC}]"
-## patch crownsnest log path
-echo -en "${WHITE}Patching crowsnest logpath ...${NOC}\r"
-patch_cn_logpath
-echo -e "${WHITE}Patching crowsnest logpath ...${NOC}[${GRE}OK${NOC}]"
-## patch crowsnest logrotate
-echo -e "${WHITE}Patching crowsnest logrotate ...${NOC}"
-patch_cn_logrotate
-echo -e "${WHITE}Patching crowsnest logrotate ...${NOC}[${GRE}OK${NOC}]"
-## fix broken links
-echo -en "${WHITE}Fix broken symlinks ...${NOC}\r"
-fix_broken_links
-fix_timelapse_links
-fix_mainsailcfg_links
-# Optional if kiauh module is used
-if [[ -d "/home/${DEFAULT_USER}/kiauh" ]]; then
-    fix_kiauh_links
-fi
-fix_cn_links
-echo -e "${WHITE}Fix broken symlinks ...${NOC}[${GRE}OK${NOC}]"
-## do a short break
-sleep 2
-## reload daemons
-echo -en "${WHITE}Apply service file changes ...${NOC}\r"
-systemctl daemon-reload
-echo -e "${WHITE}Apply service file changes ...${NOC}[${GRE}OK${NOC}]"
-## do a short break
-sleep 2
-## restart services
-echo -e "${WHITE}Trying to restart services ...${NOC}"
-start_services
-## wait 30sec to come up
-echo -e "${WHITE}Waiting 30 seconds for service restart completed ...${NOC}"
-sleep 30
-## Cleanup
-echo -e "${WHITE}Cleanup files, remove postrename ...${NOC}"
-cleanup
-sleep 2
-## reboot system
-echo -e "${WHITE}Reboot system ...${NOC}"
-reboot
+    echo -e "${GRE}Reboot system ...${NOC}"
+    reboot
+
+    exit 0
 }
 
-### MAIN
 main
-exit 0


### PR DESCRIPTION
Upgrades all MainsailOS base images from **Debian Bookworm** to **Debian Trixie** (Debian 13) and introduces **cloud-init** as the new first-boot provisioning flow — replacing the legacy `rc.local`/`firstrun` approach.

---

## Changes

### Base image upgrade to Debian Trixie

- **Raspberry Pi** (armhf & arm64): switch to `raspios_lite_*_latest` URLs (Trixie is now the current stable release)
- **Armbian** (Orange Pi 4/3 LTS, Zero2, Zero3, BTT CB1): switch to `*_trixie.img.xz` artifacts from `mainsail-crew/armbian-builds`
- Use `custopizer@main` branch in the build & release workflow to support Trixie image customisation

### Klipper: Python 3.13 & dependency changes

Trixie ships **Python 3.13** as the system default, which breaks the previously pinned `numpy<1.26`:

- Drop the `numpy<1.26` pin — install the latest `numpy` instead
- `libatlas-base-dev` was merged into `libopenblas-dev` in Trixie and is no longer available as a separate package — only add it to the dependency list when `apt` still knows about it (Bookworm and older)

### Crowsnest: switch to v5

Crowsnest v5 manages its own dependency installation, removing the need for our `pkglist-*.sh` sourcing:

- Remove the now-obsolete `pkglist-generic.sh` / `pkglist-rpi.sh` sourcing step
- Only `git` and `make` remain as build-time dependencies on our side

### Raspberry Pi: system configuration for Trixie

Trixie-based Raspberry Pi OS no longer ships a preconfigured `pi` user or enables several services that Bookworm had enabled by default. The build modules now handle the full setup:

- Set `BASE_PASSWORD` in `00-config` (default: `raspberry`)
- Use `/usr/lib/userconf-pi/userconf` with an OpenSSL-generated SHA-512 hash to create the base user and disable `userconfig.service`
- Explicitly enable `getty@tty1` and `sshd` (via `imager_custom enable_ssh` when available, with `systemctl` fallback)
- Handle passwordless sudo via `raspi-config nonint do_sudo_pass` on Trixie, with a legacy `sudoers.d` fallback for older images — `98-remove-passwordless-sudo` mirrors both code paths
- Support the new **`rpi-swap`** backend (Trixie replaced `dphys-swapfile`) by writing a drop-in config to `/etc/rpi/swap.conf.d/10-mainsailos.conf` while keeping the legacy `dphys-swapfile` path for Bookworm images

### Cloud-init: new first-boot provisioning flow

Introduces **cloud-init** as the new init format, replacing the legacy `rc.local`-style `firstrun` script. This makes MainsailOS fully compatible with **Raspberry Pi Imager** customisation (hostname, user, SSH key, WiFi) on all supported boards.

**Generic module** (`modules/generic/61-postrename-cloudinit`):

- Installs `cloud-init` + `python3-yaml` and deploys two oneshot systemd units:
  - `mainsailos-prerename.service` — reads cloud-init `user-data`, maps the target username onto the pre-built `pi` user, renames the account/group/home directory and applies the password hash via `usermod -p`
  - `mainsailos-postrename.service` — runs after `cloud-init.target` / `cloud-final.service`, wraps every path-fixup transform in `run_step()`, logs to `/var/log/mainsailos-postrename.log`, self-disables on completion and triggers a detached reboot
- `@BOOT_REQUIRE@` is substituted based on `BOOT_PATH` (`/boot` vs `/boot/firmware`)

**Armbian module** (`modules/armbian/13-armbian-cloudinit`):

- Installs `cloud-init` and configures the **NoCloud** datasource pointing at `/boot` (RPi Imager writes seed files there on Armbian)
- Ships placeholder `meta-data`, `user-data` and `network-config` seed files
- Disables and masks `armbian-firstrun-config.service` to avoid conflicts
